### PR TITLE
Upgrades minimist package to 1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthline/next",
-  "version": "25.0.0",
+  "version": "25.0.1",
   "description": "Minimalistic framework for server-rendered React applications",
   "main": "./node/server/next.js",
   "license": "MIT",
@@ -45,7 +45,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "htmlescape": "^1.1.1",
-    "minimist": "^1.2.0",
+    "minimist": "1.2.5",
     "mitt": "^1.2.0",
     "prop-types": "^15.7.0",
     "querystring": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3885,7 +3885,12 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.0, minimist@^1.2.0:
+minimist@1.2.5, minimist@^1.2.0:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=


### PR DESCRIPTION
minimist package has low severity security issue with Prototype Pollution, this upgrades the package to 1.2.5 which unaffected by the security issue

https://redventures.atlassian.net/browse/RVHLPP-94
