### PR TITLE
[HLMR-2079] Pass `maxRetries` config values to webpack

### DIFF
--- a/server/webpack.js
+++ b/server/webpack.js
@@ -57,6 +57,7 @@ export default async function createCompiler (dir, { buildId = '-', dev = false 
     dir,
     dev,
     configModule: require.resolve('./config'),
+    maxRetries: config.maxRetries,
     maxConcurrentWorkers: config.maxConcurrentWorkers
   })
 }


### PR DESCRIPTION
Discovered with fixing [HLMR-2079](https://rvohealth.atlassian.net/browse/HLMR-2079)