### PR TITLE
Update six-million versioning to match FE

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
-    "@healthline/six-million": "^8.0.3",
+    "@healthline/six-million": "~8.1.0",
     "babel-eslint": "10.0.3",
     "lint-staged": "8.2.1",
     "node-notifier": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,10 +1137,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@healthline/six-million@^8.0.3":
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/@healthline/six-million/-/six-million-8.0.3.tgz#058e331a9227919efda82c83d40e755921f2595c"
-  integrity sha512-gJwIihwQhgAxHqsAlSjBQZvbHTlbgasDNvAn0nLsZyw+gz8ZFPCyySSyJyvup5/Ls9MhqcP1kY5nmKc6SQa/lA==
+"@healthline/six-million@~8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@healthline/six-million/-/six-million-8.1.0.tgz#609c046997d27db1a64a919bf10a4ade417ec5f4"
+  integrity sha512-u3OneeZfq0D6YkVbbtiWtlNHQJMLh5UCPuX6XAuImqc5fx9UqqIk62a21nmi6g69DE6DAu80Li6kuQv6VePOOg==
   dependencies:
     "@babel/core" "^7.25.7"
     "@babel/helper-builder-react-jsx" "7.25.7"
@@ -1171,7 +1171,7 @@
     fs-readdir-recursive "^1.1.0"
     glob "^7.1.3"
     glob-promise "^3.4.0"
-    loader-utils "^1.2.1"
+    loader-utils "^1.4.2"
     mz "^2.7.0"
     output-file-sync "^2.0.1"
     promise-polyfill "^8.1.0"
@@ -4144,16 +4144,7 @@ loader-utils@^1.0.2:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-loader-utils@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
-  integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^2.0.0"
-    json5 "^1.0.1"
-
-loader-utils@^1.2.3:
+loader-utils@^1.2.3, loader-utils@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
   integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==


### PR DESCRIPTION
`six-million` versioning in the `frontend` repo was updated in https://github.com/healthline/frontend/pull/16000 and subsequently upgraded in https://github.com/healthline/frontend/pull/16001. 

This PR updates `nextjs` to match the `six-million` version used by FE. This will hopefully help address security issues that reference package versions used by `six-million v8.0.3`, e.g. https://github.com/healthline/next.js/security/dependabot/6

To test, I ran `yarn link` within this repo locally. Then, `yarn link "@healthline/next"` followed by `yarn next:build` in `frontend`