### PR TITLE
Hlmr 5657 updated version with six million update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthline/next",
-  "version": "26.1.0",
+  "version": "26.1.1",
   "description": "Minimalistic framework for server-rendered React applications",
   "main": "./node/server/next.js",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,4 @@ Minimialist version of Next.js. Not intended for external consumption.
 
 6. **Verify** the package on the [npm page](https://www.npmjs.com/package/@healthline/next?activeTab=versions).
 
-7. **Commit & Push** version changes:
-
-   ```bash
-   git add package.json
-   git commit -m "Bump version to x.y.z"
-   git push origin master
-   ```
+7. **Commit & Push** Commit & Push Open a PR to merge version change into master


### PR DESCRIPTION
Updating version and updating publishing steps as part of https://rvohealth.atlassian.net/browse/HLMR-5657

will update release notes on https://github.com/healthline/next.js/releases/new after merging this in so it's in the changelog 