### PR TITLE
[HLMR-1711] Update modern browser versions

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -3,9 +3,9 @@ const createPreset = require('@healthline/six-million/babel').default
 const isJest = !!process.env.JEST_WORKER_ID
 const isServer = !!process.env.IS_SERVER || isJest
 exports.modernBrowsers = {
-  ios: '11.3',
-  chrome: '70',
-  firefox: '60'
+  ios: '12.5.5',
+  chrome: '87',
+  firefox: '78'
 }
 
 module.exports = (context, opts = {}) => {

--- a/server/compile-targets.js
+++ b/server/compile-targets.js
@@ -1,5 +1,5 @@
 export const modernBrowsers = {
-  ios: '11.3',
-  chrome: '70',
-  firefox: '60'
+  ios: '12.5.5',
+  chrome: '87',
+  firefox: '78'
 }


### PR DESCRIPTION
https://rvohealth.atlassian.net/browse/HLMR-1711

## Description
The above ticket aims to remove the `isLegacy` flag from our next builds. The first step of this work is reflected in this PR. It updates the existing modern browser versions that we support. IIRC, these versions were decided based off user data.

edit: I explored setting % based browser targets as suggested by the comments/blog link in the linked ticket but our app would not bundle (many errors related to being unable to find imports). As such, moving forward with the originally suggested version updates in the ticket. 

## Changes
- Update `modernBrowsers` to support chrome 87, firefox 78, and ios 12.5.5 at the least

## Testing
To test, I linked these changes to `frontend` and ran `yarn build:analyze` to ensure bundle sizes were similar (went up by ~0.14)

