### PR TITLE
[HLMR-1711] Babel: Remove modernBrowsers variable

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -2,16 +2,10 @@ const createPreset = require('@healthline/six-million/babel').default
 
 const isJest = !!process.env.JEST_WORKER_ID
 const isServer = !!process.env.IS_SERVER || isJest
-exports.modernBrowsers = {
-  ios: '11.3',
-  chrome: '70',
-  firefox: '60'
-}
 
 module.exports = (context, opts = {}) => {
   opts = {
-    ...opts,
-    modernBrowsers: require('./node/server/compile-targets').modernBrowsers
+    ...opts
   }
   const preset = createPreset(context, opts)
   preset.plugins.push(

--- a/server/compile-targets.js
+++ b/server/compile-targets.js
@@ -1,5 +1,0 @@
-export const modernBrowsers = {
-  ios: '11.3',
-  chrome: '70',
-  firefox: '60'
-}


### PR DESCRIPTION
[HLMR-1711](https://rvohealth.atlassian.net/browse/HLMR-1711)

## Description
The above ticket aims to remove the isLegacy flag from our next builds. This PR follows-up changes introduced in `six-million` (https://github.com/healthline/six-million/pull/49). Now, we are defining browser targets in `six-million` so the need for `modernBrowsers` in this repo are irrelevated/unneeded.

See flowchart for how `modernBrowsers` is used
<img width="1333" alt="Screenshot 2025-04-30 at 12 24 20 PM" src="https://github.com/user-attachments/assets/0e397ad6-6ea3-4c5d-b959-59b821b58b6d" />

In follow-up work, we will explore removing the isLegacy flag. 

## Changes
- Remove `modernBrowsers` var and references to it
- Remove `serveModern` var and references to it as this was set based on if the user was navigating via a "modern" browser. We can assume, at this point, most, if not all, users have been receiving the modern experience.

## Testing
To test, I linked these changes to frontend and ran yarn build:analyze to ensure bundle sizes were similar


[HLMR-1711]: https://rvohealth.atlassian.net/browse/HLMR-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ