### PR TITLE
[HLMR-1711] Remove isLegacy flag/checks

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,37 +1,37 @@
 /* global __NEXT_DATA__ */
-import { createElement, startTransition } from "react";
-import mitt from "mitt";
-import { waitForPage } from "../lib/page-loader";
-import router, { createRouter } from "./router";
-import { getURL } from "../lib/url";
-import { hydrateRoot } from "react-dom/client";
+import { createElement, startTransition } from 'react'
+import mitt from 'mitt'
+import { waitForPage } from '../lib/page-loader'
+import router, { createRouter } from './router'
+import { getURL } from '../lib/url'
+import { hydrateRoot } from 'react-dom/client'
 
-const { props, err, pathname, query } = __NEXT_DATA__;
+const { props, err, pathname, query } = __NEXT_DATA__
 
 __webpack_public_path__ = __NEXT_DATA__.publicPath; // eslint-disable-line
 
-const asPath = getURL();
+const asPath = getURL()
 
-const appContainer = document.getElementById("__next");
+const appContainer = document.getElementById('__next')
 
-let lastAppProps;
-let ErrorComponent;
-let reactRoot = null;
+let lastAppProps
+let ErrorComponent
+let reactRoot = null
 
-export const emitter = mitt();
+export const emitter = mitt()
 
-let Enhancer;
-export function setEnhancer(_enhancer) {
-  Enhancer = _enhancer;
+let Enhancer
+export function setEnhancer (_enhancer) {
+  Enhancer = _enhancer
 }
 
 export default () => {
   return Promise.all([
-    waitForPage("/_error"),
-    waitForPage(pathname).catch(console.error),
+    waitForPage('/_error'),
+    waitForPage(pathname).catch(console.error)
   ]).then(([_ErrorComponent, Component]) => {
-    ErrorComponent = _ErrorComponent;
-    Component = Component || ErrorComponent;
+    ErrorComponent = _ErrorComponent
+    Component = Component || ErrorComponent
 
     createRouter(
       pathname,
@@ -39,26 +39,26 @@ export default () => {
       asPath,
       {
         Component,
-        err,
+        err
       },
       render
-    );
+    )
 
-    render({ Component, props, err });
+    render({ Component, props, err })
 
-    return emitter;
-  });
-};
+    return emitter
+  })
+}
 
-export function render({ Component, props, err }) {
+export function render ({ Component, props, err }) {
   // There are some errors we should ignore.
   // Next.js rendering logic knows how to handle them.
   // These are specially 404 errors
   if (err && !err.ignore) {
-    return renderError(err);
+    return renderError(err)
   }
 
-  let loadProps;
+  let loadProps
   if (
     !props &&
     Component &&
@@ -66,71 +66,71 @@ export function render({ Component, props, err }) {
     lastAppProps.Component === ErrorComponent
   ) {
     // fetch props if ErrorComponent was replaced with a page component by HMR
-    const { pathname, query, asPath } = router.url;
-    loadProps = Component.getInitialProps({ err, pathname, query, asPath });
+    const { pathname, query, asPath } = router.url
+    loadProps = Component.getInitialProps({ err, pathname, query, asPath })
   } else {
-    loadProps = Promise.resolve(props);
+    loadProps = Promise.resolve(props)
   }
 
   return loadProps
     .then((props) => {
-      Component = Component || lastAppProps.Component;
-      props = props || lastAppProps.props;
+      Component = Component || lastAppProps.Component
+      props = props || lastAppProps.props
 
-      const appProps = { Component, props, err, router };
+      const appProps = { Component, props, err, router }
       // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
-      lastAppProps = appProps;
+      lastAppProps = appProps
 
-      emitter.emit("before-reactdom-render", {
+      emitter.emit('before-reactdom-render', {
         Component,
         ErrorComponent,
-        appProps,
-      });
+        appProps
+      })
       renderReactElement(
         createElement(Component, { url: router.url, ...props }),
         appContainer
-      );
-      emitter.emit("after-reactdom-render", {
+      )
+      emitter.emit('after-reactdom-render', {
         Component,
         ErrorComponent,
-        appProps,
-      });
+        appProps
+      })
     })
     .catch((err) => {
-      if (err.abort) return;
-      return renderError(err);
-    });
+      if (err.abort) return
+      return renderError(err)
+    })
 }
 
 // This method handles all runtime and debug errors.
 // 404 and 500 errors are special kind of errors
 // and they are still handle via the main render method.
-export function renderError(error) {
+export function renderError (error) {
   return ErrorComponent.getInitialProps({
     err: error,
     pathname,
     query,
-    asPath,
+    asPath
   }).then((props) => {
-    const appProps = { Component: ErrorComponent, props, err: error, router };
-    emitter.emit("before-reactdom-render", { ErrorComponent, appProps });
-    renderReactElement(createElement(ErrorComponent, props), appContainer);
-    emitter.emit("after-reactdom-render", { ErrorComponent, appProps });
-  });
+    const appProps = { Component: ErrorComponent, props, err: error, router }
+    emitter.emit('before-reactdom-render', { ErrorComponent, appProps })
+    renderReactElement(createElement(ErrorComponent, props), appContainer)
+    emitter.emit('after-reactdom-render', { ErrorComponent, appProps })
+  })
 }
 
 // This method is responsible for rending react elements in the DOM.
 // If the root has not been defined yet, it will hydrate the element.
 // If the root has already been defined, it will use startTransition to update the tree.
-function renderReactElement(reactEl, domEl) {
+function renderReactElement (reactEl, domEl) {
   // Wrap page in app-level enhancer, if defined
-  reactEl = Enhancer ? createElement(Enhancer, null, reactEl) : reactEl;
+  reactEl = Enhancer ? createElement(Enhancer, null, reactEl) : reactEl
 
   if (!reactRoot) {
-    reactRoot = hydrateRoot(domEl, reactEl);
+    reactRoot = hydrateRoot(domEl, reactEl)
   } else {
     startTransition(() => {
-      reactRoot.render(reactEl);
-    });
+      reactRoot.render(reactEl)
+    })
   }
 }

--- a/server/document.js
+++ b/server/document.js
@@ -146,7 +146,7 @@ export class NextScript extends Component {
     const scripts = this.getScripts()
     if (!scripts.length && pathname !== '/_error') {
       throw new Error(
-        `No scripts found for ${pathname}. Please check path and SKIP_LEGACY filter`
+        `No scripts found for ${pathname}. Please check path`
       )
     }
 

--- a/server/index.js
+++ b/server/index.js
@@ -90,18 +90,6 @@ export default class Server {
       throw new Error(`No entry points defined for SITE ${process.env.SITE}`)
     }
     const current = entrypoints[process.env.SITE || 'default']
-    const legacy = entrypoints[`${process.env.SITE}-legacy`]
-
-    if (legacy) {
-      const ret = {}
-      Object.keys(current).forEach((path) => {
-        ret[path] = {
-          chunks: current[path].chunks.concat(legacy[path].chunks)
-        }
-      })
-      return ret
-    }
-
     return current
   }
 

--- a/server/render.js
+++ b/server/render.js
@@ -93,7 +93,7 @@ export async function doDocRender (page, initialProps, { amp, dev, dir, publicPa
               .filter(name => !/\.map$/.test(name) && !/hot-update.js/.test(name))
               .map(file => ({
                 file,
-                module: !/-legacy\.js/.test(file)
+                module: true
               }))
           )
         }

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -6,25 +6,14 @@ export default async function createCompiler (dir, { buildId = '-', dev = false 
   dir = resolve(dir)
   const config = getConfig(dir)
   let sites = []
-  if (config.sites) {
-    config.sites.forEach(site => {
-      sites.push({
-        name: site,
-        buildId: `${buildId}/${site}`,
-        define: { 'process.env.SITE': JSON.stringify(site) }
-      })
-      if (!process.env.SKIP_LEGACY) {
-        sites.push({
-          name: `${site}-legacy`,
-          buildId: `${buildId}/${site}`,
-          isLegacy: true,
-          define: { 'process.env.SITE': JSON.stringify(site) }
-        })
-      }
+  config.sites.forEach(site => {
+    sites.push({
+      name: site,
+      buildId: `${buildId}/${site}`,
+      define: { 'process.env.SITE': JSON.stringify(site) }
     })
-  } else {
-    sites = [ { name: 'default', buildId }, { name: 'default', buildId, isLegacy: true } ]
-  }
+  })
+
   const mainJS = dev
     ? require.resolve('../../browser/client/next-dev') : require.resolve('../../browser/client/next')
 


### PR DESCRIPTION
[HLMR-1711](https://rvohealth.atlassian.net/browse/HLMR-1711)

## Description
This PR is a follow-up to hhttps://github.com/healthline/next.js/pull/36. With our recently upgraded and co-located (within six-million) updated browser target list (that generously accounts for older browsers), we no longer need the `isLegacy` check. 

## Changes
- Remove `modernBrowsers` var and references to it
- Remove `serveModern` var and references to it as this was set based on if the user was navigating via a "modern" browser. We can assume, at this point, most, if not all, users have been receiving the modern experience.

**NOTE:** A large portion of the diff includes lint related changes. I have left PR comments on the lines that specifically relate to the `isLegacy` variable, for clarity

## Testing
To test, I linked these changes to frontend and ran yarn build:analyze to ensure bundle sizes were similar


[HLMR-1711]: https://rvohealth.atlassian.net/browse/HLMR-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ