### PR TITLE
[HLMR-1711]: Remove additional legacy code

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,37 +1,37 @@
 /* global __NEXT_DATA__ */
-import { createElement, startTransition } from "react";
-import mitt from "mitt";
-import { waitForPage } from "../lib/page-loader";
-import router, { createRouter } from "./router";
-import { getURL } from "../lib/url";
-import { hydrateRoot } from "react-dom/client";
+import { createElement, startTransition } from 'react'
+import mitt from 'mitt'
+import { waitForPage } from '../lib/page-loader'
+import router, { createRouter } from './router'
+import { getURL } from '../lib/url'
+import { hydrateRoot } from 'react-dom/client'
 
-const { props, err, pathname, query } = __NEXT_DATA__;
+const { props, err, pathname, query } = __NEXT_DATA__
 
 __webpack_public_path__ = __NEXT_DATA__.publicPath; // eslint-disable-line
 
-const asPath = getURL();
+const asPath = getURL()
 
-const appContainer = document.getElementById("__next");
+const appContainer = document.getElementById('__next')
 
-let lastAppProps;
-let ErrorComponent;
-let reactRoot = null;
+let lastAppProps
+let ErrorComponent
+let reactRoot = null
 
-export const emitter = mitt();
+export const emitter = mitt()
 
-let Enhancer;
-export function setEnhancer(_enhancer) {
-  Enhancer = _enhancer;
+let Enhancer
+export function setEnhancer (_enhancer) {
+  Enhancer = _enhancer
 }
 
 export default () => {
   return Promise.all([
-    waitForPage("/_error"),
-    waitForPage(pathname).catch(console.error),
+    waitForPage('/_error'),
+    waitForPage(pathname).catch(console.error)
   ]).then(([_ErrorComponent, Component]) => {
-    ErrorComponent = _ErrorComponent;
-    Component = Component || ErrorComponent;
+    ErrorComponent = _ErrorComponent
+    Component = Component || ErrorComponent
 
     createRouter(
       pathname,
@@ -39,26 +39,26 @@ export default () => {
       asPath,
       {
         Component,
-        err,
+        err
       },
       render
-    );
+    )
 
-    render({ Component, props, err });
+    render({ Component, props, err })
 
-    return emitter;
-  });
-};
+    return emitter
+  })
+}
 
-export function render({ Component, props, err }) {
+export function render ({ Component, props, err }) {
   // There are some errors we should ignore.
   // Next.js rendering logic knows how to handle them.
   // These are specially 404 errors
   if (err && !err.ignore) {
-    return renderError(err);
+    return renderError(err)
   }
 
-  let loadProps;
+  let loadProps
   if (
     !props &&
     Component &&
@@ -66,71 +66,71 @@ export function render({ Component, props, err }) {
     lastAppProps.Component === ErrorComponent
   ) {
     // fetch props if ErrorComponent was replaced with a page component by HMR
-    const { pathname, query, asPath } = router.url;
-    loadProps = Component.getInitialProps({ err, pathname, query, asPath });
+    const { pathname, query, asPath } = router.url
+    loadProps = Component.getInitialProps({ err, pathname, query, asPath })
   } else {
-    loadProps = Promise.resolve(props);
+    loadProps = Promise.resolve(props)
   }
 
   return loadProps
     .then((props) => {
-      Component = Component || lastAppProps.Component;
-      props = props || lastAppProps.props;
+      Component = Component || lastAppProps.Component
+      props = props || lastAppProps.props
 
-      const appProps = { Component, props, err, router };
+      const appProps = { Component, props, err, router }
       // lastAppProps has to be set before ReactDom.render to account for ReactDom throwing an error.
-      lastAppProps = appProps;
+      lastAppProps = appProps
 
-      emitter.emit("before-reactdom-render", {
+      emitter.emit('before-reactdom-render', {
         Component,
         ErrorComponent,
-        appProps,
-      });
+        appProps
+      })
       renderReactElement(
         createElement(Component, { url: router.url, ...props }),
         appContainer
-      );
-      emitter.emit("after-reactdom-render", {
+      )
+      emitter.emit('after-reactdom-render', {
         Component,
         ErrorComponent,
-        appProps,
-      });
+        appProps
+      })
     })
     .catch((err) => {
-      if (err.abort) return;
-      return renderError(err);
-    });
+      if (err.abort) return
+      return renderError(err)
+    })
 }
 
 // This method handles all runtime and debug errors.
 // 404 and 500 errors are special kind of errors
 // and they are still handle via the main render method.
-export function renderError(error) {
+export function renderError (error) {
   return ErrorComponent.getInitialProps({
     err: error,
     pathname,
     query,
-    asPath,
+    asPath
   }).then((props) => {
-    const appProps = { Component: ErrorComponent, props, err: error, router };
-    emitter.emit("before-reactdom-render", { ErrorComponent, appProps });
-    renderReactElement(createElement(ErrorComponent, props), appContainer);
-    emitter.emit("after-reactdom-render", { ErrorComponent, appProps });
-  });
+    const appProps = { Component: ErrorComponent, props, err: error, router }
+    emitter.emit('before-reactdom-render', { ErrorComponent, appProps })
+    renderReactElement(createElement(ErrorComponent, props), appContainer)
+    emitter.emit('after-reactdom-render', { ErrorComponent, appProps })
+  })
 }
 
 // This method is responsible for rending react elements in the DOM.
 // If the root has not been defined yet, it will hydrate the element.
 // If the root has already been defined, it will use startTransition to update the tree.
-function renderReactElement(reactEl, domEl) {
+function renderReactElement (reactEl, domEl) {
   // Wrap page in app-level enhancer, if defined
-  reactEl = Enhancer ? createElement(Enhancer, null, reactEl) : reactEl;
+  reactEl = Enhancer ? createElement(Enhancer, null, reactEl) : reactEl
 
   if (!reactRoot) {
-    reactRoot = hydrateRoot(domEl, reactEl);
+    reactRoot = hydrateRoot(domEl, reactEl)
   } else {
     startTransition(() => {
-      reactRoot.render(reactEl);
-    });
+      reactRoot.render(reactEl)
+    })
   }
 }

--- a/server/document.js
+++ b/server/document.js
@@ -146,7 +146,7 @@ export class NextScript extends Component {
     const scripts = this.getScripts()
     if (!scripts.length && pathname !== '/_error') {
       throw new Error(
-        `No scripts found for ${pathname}. Please check path and SKIP_LEGACY filter`
+        `No scripts found for ${pathname}. Please check path`
       )
     }
 

--- a/server/index.js
+++ b/server/index.js
@@ -89,20 +89,8 @@ export default class Server {
     if (!entrypoints[process.env.SITE || 'default']) {
       throw new Error(`No entry points defined for SITE ${process.env.SITE}`)
     }
-    const current = entrypoints[process.env.SITE || 'default']
-    const legacy = entrypoints[`${process.env.SITE}-legacy`]
 
-    if (legacy) {
-      const ret = {}
-      Object.keys(current).forEach((path) => {
-        ret[path] = {
-          chunks: current[path].chunks.concat(legacy[path].chunks)
-        }
-      })
-      return ret
-    }
-
-    return current
+    return entrypoints[process.env.SITE || 'default']
   }
 
   async getCompilationError () {

--- a/server/render.js
+++ b/server/render.js
@@ -93,7 +93,7 @@ export async function doDocRender (page, initialProps, { amp, dev, dir, publicPa
               .filter(name => !/\.map$/.test(name) && !/hot-update.js/.test(name))
               .map(file => ({
                 file,
-                module: !/-legacy\.js/.test(file)
+                module: true
               }))
           )
         }

--- a/server/webpack.js
+++ b/server/webpack.js
@@ -13,17 +13,9 @@ export default async function createCompiler (dir, { buildId = '-', dev = false 
         buildId: `${buildId}/${site}`,
         define: { 'process.env.SITE': JSON.stringify(site) }
       })
-      if (!process.env.SKIP_LEGACY) {
-        sites.push({
-          name: `${site}-legacy`,
-          buildId: `${buildId}/${site}`,
-          isLegacy: true,
-          define: { 'process.env.SITE': JSON.stringify(site) }
-        })
-      }
     })
   } else {
-    sites = [ { name: 'default', buildId }, { name: 'default', buildId, isLegacy: true } ]
+    sites = [ { name: 'default', buildId } ]
   }
   const mainJS = dev
     ? require.resolve('../../browser/client/next-dev') : require.resolve('../../browser/client/next')

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/code-frame@^7.26.2", "@babel/code-frame@^7.27.1":
+"@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -54,7 +54,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.26.5", "@babel/generator@^7.27.1":
+"@babel/generator@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.1.tgz#862d4fad858f7208edd487c28b58144036b76230"
   integrity sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==
@@ -200,7 +200,7 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helper-string-parser@^7.25.9", "@babel/helper-string-parser@^7.27.1":
+"@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
@@ -239,7 +239,7 @@
   dependencies:
     "@babel/types" "^7.26.5"
 
-"@babel/parser@^7.26.5", "@babel/parser@^7.27.1":
+"@babel/parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.1.tgz#c55d5bed74449d1223701f1869b9ee345cc94cc9"
   integrity sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==
@@ -911,7 +911,7 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
   integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==
 
-"@babel/template@^7.24.7", "@babel/template@^7.25.7", "@babel/template@^7.25.9", "@babel/template@^7.27.1":
+"@babel/template@^7.24.7", "@babel/template@^7.25.7", "@babel/template@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.1.tgz#b9e4f55c17a92312774dfbdde1b3c01c547bbae2"
   integrity sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==
@@ -920,20 +920,7 @@
     "@babel/parser" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse@^7.0.0":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.5.tgz#6d0be3e772ff786456c1a37538208286f6e79021"
-  integrity sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==
-  dependencies:
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/parser" "^7.26.5"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.5"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.27.1":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.1.tgz#4db772902b133bbddd1c4f7a7ee47761c1b9f291"
   integrity sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==
@@ -946,21 +933,13 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@7.27.1", "@babel/types@^7.24.7", "@babel/types@^7.25.7", "@babel/types@^7.26.5", "@babel/types@^7.27.1", "@babel/types@^7.4.4":
+"@babel/types@7.27.1", "@babel/types@^7.0.0", "@babel/types@^7.24.7", "@babel/types@^7.25.7", "@babel/types@^7.26.5", "@babel/types@^7.27.1", "@babel/types@^7.4.4":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.1.tgz#9defc53c16fc899e46941fc6901a9eea1c9d8560"
   integrity sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
-
-"@babel/types@^7.0.0":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.5.tgz#7a1e1c01d28e26d1fe7f8ec9567b3b92b9d07747"
-  integrity sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==
-  dependencies:
-    "@babel/helper-string-parser" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@healthline/six-million@~8.2.0":
   version "8.2.0"


### PR DESCRIPTION
## Description
In a previous PRs for both next and six-million, we removed the isLegacy flag. However, there were still remaining areas that required cleanup that were meant to go in with the PR that upgraded our six-million version (https://github.com/healthline/next.js/pull/38). This is resulting in some errors regarding parsing legacy bundles as they do not exist. Interestingly, this does not occur locally, but only when attempting to upgrade to the most recent versions of both `six-million` and `next` in frontend. 

NOTE: A fair portion of the diff includes lint related changes, particularly in one file. I left comments beneath relevant changes

## Testing
To test, I linked these changes to frontend and ran yarn build:analyze to ensure bundle sizes were similar